### PR TITLE
ENH add ptb3 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # irit-rst-dt specific
 TMP
 corpus
+ptb3
 
 # Sphinx
 _build


### PR DESCRIPTION
Small fix to complete the .gitignore file so that the ptb3 folder, that points to a local copy of the PTB following the setup instructions, is ignored as well.
