### PR TITLE
[MRG] MAINT catch-up with perceptrons API, refactor local.py

### DIFF
--- a/irit_rst_dt/config/perceptron.py
+++ b/irit_rst_dt/config/perceptron.py
@@ -1,39 +1,31 @@
 """Configuration helpers for using perceptron based learners
 """
 
-import numpy as np
+# import numpy as np
 from sklearn import linear_model as sk
 
 from attelo.harness.config import (Keyed)
 
 from attelo.learning.perceptron import (Perceptron,
-                                        PerceptronArgs,
                                         PassiveAggressive,
                                         StructuredPerceptron,
                                         StructuredPassiveAggressive)
 from attelo.learning.local import (SklearnAttachClassifier,
                                    SklearnLabelClassifier)
 
+# parameters for local perceptrons
+LOCAL_N_ITER = 20
+LOCAL_AVG = False  # was: True
+LOCAL_USE_PROB = False
+# parameter for local passive-aggressive
+LOCAL_C = 1.0  # was: np.inf
 
-LOCAL_PERC_ARGS = PerceptronArgs(iterations=20,
-                                 averaging=True,
-                                 use_prob=False,
-                                 aggressiveness=np.inf)
-
-LOCAL_PA_ARGS = PerceptronArgs(iterations=20,
-                               averaging=True,
-                               use_prob=False,
-                               aggressiveness=np.inf)
-
-STRUCT_PERC_ARGS = PerceptronArgs(iterations=50,
-                                  averaging=True,
-                                  use_prob=False,
-                                  aggressiveness=np.inf)
-
-STRUCT_PA_ARGS = PerceptronArgs(iterations=50,
-                                averaging=True,
-                                use_prob=False,
-                                aggressiveness=np.inf)
+# parameters for structured perceptrons
+STRUC_N_ITER = 50
+STRUC_AVG = False  # was: True
+STRUC_USE_PROB = False
+# parameter for structured passive-aggressive
+STRUC_C = 1.0  # was: np.inf
 
 # ---------------------------------------------------------------------
 # scikit
@@ -42,25 +34,25 @@ STRUCT_PA_ARGS = PerceptronArgs(iterations=50,
 
 def attach_learner_perc():
     "return a keyed instance of perceptron learner"
-    learner = sk.Perceptron(n_iter=LOCAL_PERC_ARGS.iterations)
+    learner = sk.Perceptron(n_iter=LOCAL_N_ITER)
     return Keyed('perc', SklearnAttachClassifier(learner))
 
 
 def label_learner_perc():
     "return a keyed instance of perceptron learner"
-    learner = sk.Perceptron(n_iter=LOCAL_PERC_ARGS.iterations)
+    learner = sk.Perceptron(n_iter=LOCAL_N_ITER)
     return Keyed('perc', SklearnLabelClassifier(learner))
 
 
 def attach_learner_pa():
     "return a keyed instance of passive aggressive learner"
-    learner = sk.PassiveAggressiveClassifier(n_iter=LOCAL_PA_ARGS.iterations)
+    learner = sk.PassiveAggressiveClassifier(C=LOCAL_C, n_iter=LOCAL_N_ITER)
     return Keyed('pa', SklearnAttachClassifier(learner))
 
 
 def label_learner_pa():
     "return a keyed instance of passive aggressive learner"
-    learner = sk.PassiveAggressiveClassifier(n_iter=LOCAL_PA_ARGS.iterations)
+    learner = sk.PassiveAggressiveClassifier(C=LOCAL_C, n_iter=LOCAL_N_ITER)
     return Keyed('pa', SklearnLabelClassifier(learner))
 
 
@@ -71,34 +63,55 @@ def label_learner_pa():
 def attach_learner_dp_perc():
     "return a keyed instance of perceptron learner"
     return Keyed('dp-perc',
-                 SklearnAttachClassifier(Perceptron(LOCAL_PERC_ARGS)))
+                 SklearnAttachClassifier(
+                     Perceptron(n_iter=LOCAL_N_ITER,
+                                average=LOCAL_AVG,
+                                use_prob=LOCAL_USE_PROB)))
 
 
 def label_learner_dp_perc():
     "return a keyed instance of perceptron learner"
     return Keyed('dp-perc',
-                 SklearnLabelClassifier(Perceptron(LOCAL_PERC_ARGS)))
+                 SklearnLabelClassifier(
+                     Perceptron(n_iter=LOCAL_N_ITER,
+                                average=LOCAL_AVG,
+                                use_prob=LOCAL_USE_PROB)))
 
 
 def attach_learner_dp_pa():
     "return a keyed instance of passive aggressive learner"
     return Keyed('dp-pa',
-                 SklearnAttachClassifier(PassiveAggressive(LOCAL_PA_ARGS)))
+                 SklearnAttachClassifier(
+                     PassiveAggressive(C=LOCAL_C,
+                                       n_iter=LOCAL_N_ITER,
+                                       average=LOCAL_AVG,
+                                       use_prob=LOCAL_USE_PROB)))
 
 
 def label_learner_dp_pa():
     "return a keyed instance of passive aggressive learner"
     return Keyed('dp-pa',
-                 SklearnLabelClassifier(PassiveAggressive(LOCAL_PA_ARGS)))
+                 SklearnLabelClassifier(
+                     PassiveAggressive(C=LOCAL_C,
+                                       n_iter=LOCAL_N_ITER,
+                                       average=LOCAL_AVG,
+                                       use_prob=LOCAL_USE_PROB)))
 
 
 def attach_learner_dp_struct_perc(decoder):
     "structured perceptron learning"
-    learner = StructuredPerceptron(decoder, STRUCT_PERC_ARGS)
+    learner = StructuredPerceptron(decoder,
+                                   n_iter=STRUC_N_ITER,
+                                   average=STRUC_AVG,
+                                   use_prob=STRUC_USE_PROB)
     return Keyed('dp-struct-perc', learner)
 
 
 def attach_learner_dp_struct_pa(decoder):
     "structured passive-aggressive learning"
-    learner = StructuredPassiveAggressive(decoder, STRUCT_PA_ARGS)
+    learner = StructuredPassiveAggressive(decoder,
+                                          C=STRUC_C,
+                                          n_iter=STRUC_N_ITER,
+                                          average=STRUC_AVG,
+                                          use_prob=STRUC_USE_PROB)
     return Keyed('dp-struct-pa', learner)

--- a/irit_rst_dt/config/perceptron.py
+++ b/irit_rst_dt/config/perceptron.py
@@ -15,15 +15,15 @@ from attelo.learning.local import (SklearnAttachClassifier,
 
 # parameters for local perceptrons
 LOCAL_N_ITER = 20
-LOCAL_AVG = False  # was: True
-LOCAL_USE_PROB = False
+LOCAL_AVG = True  # NB: sklearn perceptrons don't offer this option
+LOCAL_USE_PROB = False  # NB: True would currently have no effect
 # parameter for local passive-aggressive
 LOCAL_C = 1.0  # was: np.inf
 
 # parameters for structured perceptrons
 STRUC_N_ITER = 50
-STRUC_AVG = False  # was: True
-STRUC_USE_PROB = False
+STRUC_AVG = True  # NB: ibid
+STRUC_USE_PROB = False  # NB: ibid
 # parameter for structured passive-aggressive
 STRUC_C = 1.0  # was: np.inf
 

--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -24,7 +24,6 @@ from attelo.parser.intra import (IntraInterPair,
                                  HeadToHeadParser,
                                  # SentOnlyParser,
                                  SoftParser)
-from attelo.util import (concat_l)
 
 from sklearn.linear_model import (LogisticRegression)
 from sklearn.tree import DecisionTreeClassifier
@@ -213,7 +212,7 @@ We assume that they cannot be used relation modelling
 """
 
 
-def _core_parsers(klearner):
+def _core_parsers(klearner, unique_real_root=True):
     """Our basic parser configurations
     """
     # joint
@@ -226,7 +225,9 @@ def _core_parsers(klearner):
                 # decoder_last(),
                 # DECODER_LOCAL,
                 # decoder_mst(),
-                decoder_eisner(),
+                Keyed('eisner',
+                      EisnerDecoder(unique_real_root=unique_real_root,
+                                    use_prob=True)),
             ]
         ]
 
@@ -236,7 +237,9 @@ def _core_parsers(klearner):
             # decoder_last() ,
             # DECODER_LOCAL,
             # decoder_mst(),
-            decoder_eisner(),
+            Keyed('eisner',
+                  EisnerDecoder(unique_real_root=unique_real_root,
+                                use_prob=True)),
         ]
     ]
 
@@ -257,11 +260,16 @@ _INTRA_INTER_CONFIGS = [
 HARNESS_NAME = 'irit-rst-dt'
 
 
+# possibly obsolete
 def _mk_basic_intras(klearner, kconf):
     """Intra/inter parser based on a single core parser
     """
-    return [combine_intra(IntraInterPair(x, x), kconf)
-            for x in _core_parsers(klearner)]
+    # NEW intra parsers are explicitly authorized to have more than one
+    # real root (necessary for the Eisner decoder, maybe other decoders too)
+    parsers = [IntraInterPair(intra=x, inter=y) for x, y in
+               zip(_core_parsers(klearner, unique_real_root=False),
+                   _core_parsers(klearner))]
+    return [combine_intra(p, kconf) for p in parsers]
 
 
 def _mk_sorc_intras(klearner, kconf):
@@ -269,7 +277,8 @@ def _mk_sorc_intras(klearner, kconf):
     and a sentence oracle
     """
     parsers = [IntraInterPair(intra=x, inter=y) for x, y in
-               zip(_core_parsers(ORACLE), _core_parsers(klearner))]
+               zip(_core_parsers(ORACLE, unique_real_root=False),
+                   _core_parsers(klearner))]
     return [combine_intra(p, kconf, primary='inter') for p in parsers]
 
 
@@ -278,7 +287,8 @@ def _mk_dorc_intras(klearner, kconf):
     and a document oracle
     """
     parsers = [IntraInterPair(intra=x, inter=y) for x, y in
-               zip(_core_parsers(klearner), _core_parsers(ORACLE))]
+               zip(_core_parsers(klearner, unique_real_root=False),
+                   _core_parsers(ORACLE))]
     return [combine_intra(p, kconf, primary='intra') for p in parsers]
 
 
@@ -292,10 +302,10 @@ def _mk_last_intras(klearner, kconf):
     kconf = Keyed(key=combined_key('last', kconf),
                   payload=kconf.payload)
     econf_last = mk_joint(klearner, decoder_last())
-    return [combine_intra(IntraInterPair(intra=econf_last, inter=p),
-                          kconf,
-                          primary='inter')
-            for p in _core_parsers(klearner)]
+    parsers = [IntraInterPair(intra=econf_last, inter=y) for y in
+               _core_parsers(klearner)]
+    return [combine_intra(p, kconf, primary='inter') for p in parsers]
+# end of possibly obsolete
 
 
 def _is_junk(econf):
@@ -327,26 +337,58 @@ def _is_junk(econf):
 
 def _evaluations():
     "the evaluations we want to run"
-    # list of learners, local and structured
+    res = []
+
+    # == one-step (global) parsers ==
     learners = []
     learners.extend(_LOCAL_LEARNERS)
-    # current structured learners don't do probs
-    # hence non-prob decoders
-    # nonprob_mst = MstDecoder(MstRootStrategy.fake_root, False)
-    # learners.extend(l(nonprob_mst) for l in _STRUCTURED_LEARNERS)
+    # current structured learners don't do probs, hence non-prob decoders
     nonprob_eisner = EisnerDecoder(use_prob=False)
     learners.extend(l(nonprob_eisner) for l in _STRUCTURED_LEARNERS)
-    # cross-product of learners and intra/inter-sentential configs
-    ipairs = list(itr.product(learners, _INTRA_INTER_CONFIGS))
-    # concatenate all of the above configurations, plus sentence-
-    # and document-level oracles for intra/inter configs
-    res = concat_l([
-        concat_l(_core_parsers(l) for l in learners),
-        concat_l(_mk_basic_intras(l, x) for l, x in ipairs),
-        concat_l(_mk_sorc_intras(l, x) for l, x in ipairs),
-        concat_l(_mk_dorc_intras(l, x) for l, x in ipairs),
-        concat_l(_mk_last_intras(l, x) for l, x in ipairs),
-    ])
+    # MST is disabled by default, as it does not output projective trees
+    # nonprob_mst = MstDecoder(MstRootStrategy.fake_root, False)
+    # learners.extend(l(nonprob_mst) for l in _STRUCTURED_LEARNERS)
+    global_parsers = itr.chain.from_iterable(_core_parsers(l)
+                                             for l in learners)
+    res.extend(global_parsers)
+
+    # == two-step parsers: intra then inter-sentential ==
+    ii_learners = []  # (intra, inter) learners
+    ii_learners.extend((klearner, klearner)
+                       for klearner in _LOCAL_LEARNERS)
+    # structured learners, cf. supra
+    intra_nonprob_eisner = EisnerDecoder(use_prob=False,
+                                         unique_real_root=False)
+    inter_nonprob_eisner = EisnerDecoder(use_prob=False,
+                                         unique_real_root=True)
+    ii_learners.extend((l(intra_nonprob_eisner), l(inter_nonprob_eisner))
+                       for l in _STRUCTURED_LEARNERS)
+    # couples of learners with either sentence- or document-level oracle
+    sorc_ii_learners = [
+        (ORACLE, inter_lnr) for intra_lnr, inter_lnr in ii_learners
+    ]
+    dorc_ii_learners = [
+        (intra_lnr, ORACLE) for intra_lnr, inter_lnr in ii_learners
+    ]
+    # enumerate pairs of (intra, inter) parsers
+    ii_pairs = []
+    for intra_lnr, inter_lnr in itr.chain(ii_learners,
+                                          sorc_ii_learners,
+                                          dorc_ii_learners):
+        # NEW intra parsers are explicitly authorized (in fact, expected)
+        # to have more than one real root ; this is necessary for the
+        # Eisner decoder and probably others, with "hard" strategies
+        ii_pairs.extend(IntraInterPair(intra=x, inter=y) for x, y in
+                        zip(_core_parsers(intra_lnr, unique_real_root=False),
+                            _core_parsers(inter_lnr, unique_real_root=True)))
+    # cross-product: pairs of parsers x intra-/inter- configs
+    ii_parsers = [combine_intra(p, kconf,
+                                primary=('inter' if p.intra.settings.oracle
+                                         else 'intra'))
+                  for p, kconf
+                  in itr.product(ii_pairs, _INTRA_INTER_CONFIGS)]
+    res.extend(ii_parsers)
+
     return [x for x in res if not _is_junk(x)]
 
 

--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -232,6 +232,7 @@ def _core_parsers(klearner, unique_real_root=True):
         ]
 
     # postlabeling
+    use_prob = klearner.attach.payload.can_predict_proba
     post = [
         mk_post(klearner, d) for d in [
             # decoder_last() ,
@@ -239,7 +240,7 @@ def _core_parsers(klearner, unique_real_root=True):
             # decoder_mst(),
             Keyed('eisner',
                   EisnerDecoder(unique_real_root=unique_real_root,
-                                use_prob=True)),
+                                use_prob=use_prob)),
         ]
     ]
 


### PR DESCRIPTION
This PR contains a catch-up with the API of the perceptrons after irit-melodi/attelo#48 and a refactoring of `local.py` to better control experimental setups.