### PR TITLE
[MRG] FIX model paths for inter-sent

### DIFF
--- a/irit_rst_dt/harness.py
+++ b/irit_rst_dt/harness.py
@@ -133,8 +133,8 @@ class IritHarness(Harness):
 
         if isinstance(rconf, IntraInterPair):
             return {
-                'inter:attach': _eval_model_path(rconf.inter, "attach"),
-                'inter:label': _eval_model_path(rconf.inter, "relate"),
+                'inter:attach': _eval_model_path(rconf.inter, "doc-attach"),
+                'inter:label': _eval_model_path(rconf.inter, "doc-relate"),
                 'intra:attach': _eval_model_path(rconf.intra, "sent-attach"),
                 'intra:label': _eval_model_path(rconf.intra, "sent-relate")
             }

--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -263,7 +263,7 @@ def _core_parsers(klearner, unique_real_root=True):
 _INTRA_INTER_CONFIGS = [
     Keyed('iheads', HeadToHeadParser),
     # Keyed('ionly', SentOnlyParser),
-    Keyed('isoft', SoftParser),
+    # Keyed('isoft', SoftParser),
 ]
 
 


### PR DESCRIPTION
This PR fixes the model paths for inter-sentential parsers.

Until now, inter-sentential parsers used global models with good results, but recent experiments indicate that specific inter models can provide a slight improvement in scores.

In the future, intra-inter parsers should accept an argument to choose between a global and a specific model for inter-sentential edges. 