### PR TITLE
[MRG] FIX perceptrons verbosity

### DIFF
--- a/irit_rst_dt/config/perceptron.py
+++ b/irit_rst_dt/config/perceptron.py
@@ -13,6 +13,8 @@ from attelo.learning.perceptron import (Perceptron,
 from attelo.learning.local import (SklearnAttachClassifier,
                                    SklearnLabelClassifier)
 
+
+VERBOSE = 2  # verbosity level
 # parameters for local perceptrons
 LOCAL_N_ITER = 20
 LOCAL_AVG = True  # NB: sklearn perceptrons don't offer this option
@@ -21,7 +23,7 @@ LOCAL_USE_PROB = False  # NB: True would currently have no effect
 LOCAL_C = 1.0  # was: np.inf
 
 # parameters for structured perceptrons
-STRUC_N_ITER = 50
+STRUC_N_ITER = 20  # was 50
 STRUC_AVG = True  # NB: ibid
 STRUC_USE_PROB = False  # NB: ibid
 # parameter for structured passive-aggressive
@@ -46,13 +48,15 @@ def label_learner_perc():
 
 def attach_learner_pa():
     "return a keyed instance of passive aggressive learner"
-    learner = sk.PassiveAggressiveClassifier(C=LOCAL_C, n_iter=LOCAL_N_ITER)
+    learner = sk.PassiveAggressiveClassifier(C=LOCAL_C,
+                                             n_iter=LOCAL_N_ITER)
     return Keyed('pa', SklearnAttachClassifier(learner))
 
 
 def label_learner_pa():
     "return a keyed instance of passive aggressive learner"
-    learner = sk.PassiveAggressiveClassifier(C=LOCAL_C, n_iter=LOCAL_N_ITER)
+    learner = sk.PassiveAggressiveClassifier(C=LOCAL_C,
+                                             n_iter=LOCAL_N_ITER)
     return Keyed('pa', SklearnLabelClassifier(learner))
 
 
@@ -65,6 +69,7 @@ def attach_learner_dp_perc():
     return Keyed('dp-perc',
                  SklearnAttachClassifier(
                      Perceptron(n_iter=LOCAL_N_ITER,
+                                verbose=VERBOSE,
                                 average=LOCAL_AVG,
                                 use_prob=LOCAL_USE_PROB)))
 
@@ -74,6 +79,7 @@ def label_learner_dp_perc():
     return Keyed('dp-perc',
                  SklearnLabelClassifier(
                      Perceptron(n_iter=LOCAL_N_ITER,
+                                verbose=VERBOSE,
                                 average=LOCAL_AVG,
                                 use_prob=LOCAL_USE_PROB)))
 
@@ -84,6 +90,7 @@ def attach_learner_dp_pa():
                  SklearnAttachClassifier(
                      PassiveAggressive(C=LOCAL_C,
                                        n_iter=LOCAL_N_ITER,
+                                       verbose=VERBOSE,
                                        average=LOCAL_AVG,
                                        use_prob=LOCAL_USE_PROB)))
 
@@ -94,6 +101,7 @@ def label_learner_dp_pa():
                  SklearnLabelClassifier(
                      PassiveAggressive(C=LOCAL_C,
                                        n_iter=LOCAL_N_ITER,
+                                       verbose=VERBOSE,
                                        average=LOCAL_AVG,
                                        use_prob=LOCAL_USE_PROB)))
 
@@ -102,6 +110,7 @@ def attach_learner_dp_struct_perc(decoder):
     "structured perceptron learning"
     learner = StructuredPerceptron(decoder,
                                    n_iter=STRUC_N_ITER,
+                                   verbose=VERBOSE,
                                    average=STRUC_AVG,
                                    use_prob=STRUC_USE_PROB)
     return Keyed('dp-struct-perc', learner)
@@ -112,6 +121,7 @@ def attach_learner_dp_struct_pa(decoder):
     learner = StructuredPassiveAggressive(decoder,
                                           C=STRUC_C,
                                           n_iter=STRUC_N_ITER,
+                                          verbose=VERBOSE,
                                           average=STRUC_AVG,
                                           use_prob=STRUC_USE_PROB)
     return Keyed('dp-struct-pa', learner)

--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -146,22 +146,28 @@ def decoder_eisner():
 
 def decoder_mst():
     "our instantiation of the mst decoder"
-    return Keyed('mst', MstDecoder(MstRootStrategy.fake_root, True))
+    return Keyed('mst', MstDecoder(MstRootStrategy.fake_root,
+                                   use_prob=True))
 
 
 def attach_learner_maxent():
     "return a keyed instance of maxent learner"
-    return Keyed('maxent', SklearnAttachClassifier(LogisticRegression()))
+    return Keyed('maxent',
+                 SklearnAttachClassifier(LogisticRegression(
+                     n_jobs=1)))
 
 
 def label_learner_maxent():
     "return a keyed instance of maxent learner"
-    return Keyed('maxent', SklearnLabelClassifier(LogisticRegression()))
+    return Keyed('maxent',
+                 SklearnLabelClassifier(LogisticRegression(
+                     n_jobs=1)))
 
 
 def attach_learner_dectree():
     "return a keyed instance of decision tree learner"
-    return Keyed('dectree', SklearnAttachClassifier(DecisionTreeClassifier()))
+    return Keyed('dectree',
+                 SklearnAttachClassifier(DecisionTreeClassifier()))
 
 
 def label_learner_dectree():
@@ -173,12 +179,15 @@ def label_learner_dectree():
 def attach_learner_rndforest():
     "return a keyed instance of random forest learner"
     return Keyed('rndforest',
-                 SklearnAttachClassifier(RandomForestClassifier()))
+                 SklearnAttachClassifier(RandomForestClassifier(
+                     n_estimators=100, n_jobs=1)))
 
 
 def label_learner_rndforest():
     "return a keyed instance of decision tree learner"
-    return Keyed('rndforest', SklearnLabelClassifier(RandomForestClassifier()))
+    return Keyed('rndforest',
+                 SklearnLabelClassifier(RandomForestClassifier(
+                     n_estimators=100, n_jobs=1)))
 
 
 _LOCAL_LEARNERS = [
@@ -372,7 +381,7 @@ def _evaluations():
                        for klearner in _LOCAL_LEARNERS)
     # structured learners, cf. supra
     intra_nonprob_eisner = EisnerDecoder(use_prob=False,
-                                         unique_real_root=False)
+                                         unique_real_root=True)
     inter_nonprob_eisner = EisnerDecoder(use_prob=False,
                                          unique_real_root=True)
     ii_learners.extend((copy.deepcopy(l)(intra_nonprob_eisner),


### PR DESCRIPTION
This PR is linked to irit-melodi/attelo#55 , enabling to specify a verbosity level for perceptrons.
It also brings a few modifications to fine-tune default parameters in `local.py`, notably enforcing intra-sentential decoding to select a unique real root.