### PR TITLE
ENH gather: new options "coarse", "fix_pseudo_rels"

### DIFF
--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -93,6 +93,7 @@ validation on the training data)
 TEST_EVALUATION_KEY = None
 # TEST_EVALUATION_KEY = 'maxent-AD.L-jnt-mst'
 # TEST_EVALUATION_KEY = 'maxent-AD.L-jnt-eisner'
+# TEST_EVALUATION_KEY = 'maxent-iheads-global-AD.L-jnt-eisner'
 """Evaluation to use for testing.
 
 Leave this to None until you think it's OK to look at the test data.


### PR DESCRIPTION
This PR adds two options to the `'gather` subcommand:
* `coarse` replaces fine- with coarse-grained labels,
* `fix_pseudo_rels` replaces pseudo-relations, either official (`Same-Unit`, `TextualOrganization`) or unofficial (multinuclear `Topic-Shift`) with labels that should be more accurate (separate suspicious from true Same-Unit, fix confusion between TextualOrganization and Topic-Shift...).